### PR TITLE
feat: 修复外部通过 ref 传递参数导致不兼容的 Bug

### DIFF
--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -2,7 +2,7 @@
   <div ref="selector"></div>
 </template>
 <script lang="ts">
-import { defineComponent, ref, watchEffect, PropType } from 'vue'
+import { defineComponent, ref, watchEffect, PropType, toRaw } from 'vue'
 import { createToolbar, IToolbarConfig, IDomEditor, DomEditor } from '@wangeditor/editor'
 
 export default defineComponent({
@@ -47,7 +47,7 @@ export default defineComponent({
     watchEffect( () => {
       const { editor } = props
       if (editor == null) return
-      create(editor) // 初始化 toolbar
+      create(toRaw(editor)) // 初始化 toolbar
     })
 
     return {


### PR DESCRIPTION
当外部使用 const editor = ref() 来保存 editor 实例时，editor 会被封装成 reactive(editor) 这是一个 Proxy 对象。core 中通过
weakMap.get(ProxyHandler<editor>) 会存在取不到值的问题

通过 vue 的 toRaw 可以将一个 reactive 对象还原成原始的对象，该会方法对传递
editor 时会原生返回

toRaw 方法见：https://cn.vuejs.org/api/reactivity-advanced.html#toraw